### PR TITLE
Fix a bug with inserting keywords

### DIFF
--- a/trie.py
+++ b/trie.py
@@ -15,7 +15,7 @@ class Trie:
         cur_node = self.__root
         for char in keyword:
             if not cur_node.next.get(char):
-                cur_node.next[char] = Trie()
+                cur_node.next[char] = Node()
             cur_node = cur_node.next[char]
         cur_node.is_end = True
 


### PR DESCRIPTION
Every time when a new character of a keyword was inserted into the trie, a Trie object was created rather than a Node object. It's wrong. The Node object should have been created.